### PR TITLE
Quick update

### DIFF
--- a/src/vg/civcraft/mc/civchat2/command/commands/Tell.java
+++ b/src/vg/civcraft/mc/civchat2/command/commands/Tell.java
@@ -58,7 +58,7 @@ public class Tell extends PlayerCommandMiddle{
 					builder.append(args[x] + " ");
 				//This separator needs to be changed to load from config.
 				String sep = "|";
-				MercuryPlugin.handler.sendMessage(NameLayerPlugin.getOnlineAllServers().get(args[0].toLowerCase()),"civchat2", "pm"+sep+player.getName()+sep+args[0].trim()+sep+builder.toString().replace(sep, ""));
+				MercuryPlugin.handler.sendMessage(NameLayerPlugin.getOnlineAllServers().get(args[0].toLowerCase()), "pm"+sep+player.getName()+sep+args[0].trim()+sep+builder.toString().replace(sep, ""), "civchat2");
 				player.sendMessage(ChatColor.LIGHT_PURPLE+"To "+args[0]+": "+builder.toString());
 				return true;
 			}


### PR DESCRIPTION
Made the Venus binding of Mercury handle messages from plugins in the same order as the other bindings.

Pull for Civchat2 to reflect that.
